### PR TITLE
Add Fedora installation instructions

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -18,6 +18,16 @@ and strlcat().
 Installation
 ============
 
+Fedora
+------
+
+A package is available in Fedora 25 or later.
+
+  sudo dnf install brightlight
+
+Source
+------
+
 brightlight can be compiled by issuing 'make'. Compiler options can be changed
 by editing the Makefile. The default compiler is gcc, however clang works too.
 You can then place the resulting binary somewhere in your $PATH.


### PR DESCRIPTION
brightlight was recently packaged for Fedora Linux. This commit
adds instructions on how to install the package with Fedora's
package manager, dnf.

See more info on the package here:

    https://bugzilla.redhat.com/show_bug.cgi?id=1505026

    https://copr.fedorainfracloud.org/coprs/jflory7/brightlight/

    https://src.fedoraproject.org/rpms/brightlight