### PR TITLE
Explicitly add project license in file (helpful for RPM packaging)

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,16 @@
+Copyright (C) 2016, 2017, 2018 multiplexd <multiplexd@gmx.com>
+
+Please note that from version 6 onwards brightlight has been relicenced under an
+ISC-like licence. Prior versions are under the GPL, version 2 or later.
+
+Permission to use, copy, modify, and distribute this software for any purpose
+with or without fee is hereby granted, provided that the above copyright notice
+and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
+THIS SOFTWARE.

--- a/README.txt
+++ b/README.txt
@@ -99,19 +99,4 @@ v7, 08/10/2018 - Bugfix release.
 License
 =======
 
-Copyright (C) 2016, 2017, 2018 multiplexd <multiplexd@gmx.com>
-
-Please note that from version 6 onwards brightlight has been relicenced under an
-ISC-like licence. Prior versions are under the GPL, version 2 or later.
-
-Permission to use, copy, modify, and distribute this software for any purpose
-with or without fee is hereby granted, provided that the above copyright notice
-and this permission notice appear in all copies.
-
-THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
-REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
-FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
-INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
-OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
-TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
-THIS SOFTWARE.
+See LICENSE.txt.


### PR DESCRIPTION
This PR adds a LICENSE.txt file back to the repository. It's helpful to keep the file in place for RPM packaging when specifying a license for a project. In this commit, I take the LICENSE.txt content directly from the README.